### PR TITLE
fix css margin error

### DIFF
--- a/src/toastr.less
+++ b/src/toastr.less
@@ -169,13 +169,15 @@ button.toast-close-button {
   &.toast-top-center > div,
   &.toast-bottom-center > div {
     width: 300px;
-    margin: auto;
+    margin-left: auto;
+    margin-right: auto;
   }
 
   &.toast-top-full-width > div,
   &.toast-bottom-full-width > div {
     width: 96%;
-    margin: auto;
+    margin-left: auto;
+    margin-right: auto;
   }
 }
 


### PR DESCRIPTION
Toasts have a default bottom margin of 6px. This is overwritten, when using full-width or center positions, because margin (shorthand) is set to auto.

This commit changes the margin specification to be more specific.
